### PR TITLE
Backdrop color fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ node_modules/
 /pages/
 /docs/
 /test/coverage/
+.idea/
 !.gitignore

--- a/src/fade/fade.less
+++ b/src/fade/fade.less
@@ -78,16 +78,46 @@
 
 }
 
-.modal-backdrop, .aside-backdrop {
+// Modal backdrop, uses bootstrap's color, same duration, opacity
 
-  &.am-fade {
+.modal-backdrop.am-fade,
+.aside-backdrop.am-fade {
+  animation-duration: .15s;
+  animation-timing-function: @fade-timing-function;
+  animation-fill-mode: backwards;
+  opacity: .5;
 
-    background: rgba(0, 0, 0, .5);
-    animation-duration: @fade-duration / 2;
-    &.ng-leave {
-      animation-delay: @fade-duration;
+  &.ng-enter {
+    visibility: hidden;
+    animation-name: modalBackdropFadeIn;
+    animation-play-state: paused;
+    &.ng-enter-active {
+      visibility: visible;
+      animation-play-state: running;
     }
-
   }
+  &.ng-leave {
+    animation-name: modalBackdropFadeOut;
+    animation-play-state: paused;
+    &.ng-leave-active {
+      animation-play-state: running;
+    }
+  }
+}
 
+@keyframes modalBackdropFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: .5;
+  }
+}
+@keyframes modalBackdropFadeOut {
+  from {
+    opacity: .5;
+  }
+  to {
+    opacity: 0;
+  }
 }


### PR DESCRIPTION
Fixes #18
Looked into this issue. Was confused by the angular-strap modal docs which give you backdrop transition code, yet afford you the backdrop animation in angular-motion's am-fade code. It would be best to supply this animation for them, instead of having them have to manually put it in themselves. Maybe some people don't use angular-motion though and that's what the AS doc's transition code is all about? Tried to use the transition code here, but ran into am-fade animation code that was running in parallel, so went with animation instead. Copied the am-fade animation style with visibility and backwards fill-mode, though not sure why either one of those are there. Maybe you can clarify the need, i.e. works without visibility settings and fill-mode:none (to override am-fade's fill-mode application). 

I'm not sure where all this code is used, all I know about is angular-strap. The tests are broken on a need for the karma-jasmine plugin, but didn't see any tests anyway. I tested it on angular-strap running on bootstrap 3.2.0 as the modal background still isn't fixed on bootstrap 3.3.2 last time I checked.


