### PR TITLE
Fix npm warning on latest node

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
     "ng-factory": "^1.0",
     "undertaker-lib-tasks": "^0.4.1"
   },
-  "engines": {
-    "node": "^0.10"
-  },
   "scripts": {
     "test": "gulp build"
   }


### PR DESCRIPTION
Remove engines setting as per angular-strap to squelch the following warning:

    npm WARN engine angular-motion@0.4.3: wanted: {"node":"^0.10"} (current: {"node":"4.2.1","npm":"2.14.7"})

Not tested nor am I aware of whether this "engines" setting is useful at all.