### PR TITLE
Update fade.less

### DIFF
--- a/src/fade/fade.less
+++ b/src/fade/fade.less
@@ -84,9 +84,7 @@
 
     background: rgba(0, 0, 0, .5);
     animation-duration: @fade-duration / 2;
-    &.ng-leave {
-      animation-delay: @fade-duration;
-    }
+   
 
   }
 


### PR DESCRIPTION
https://github.com/mgcrea/angular-strap/issues/2065
Screen flickers in Chrome v49 and Firefox v45.0.1 after closing modal/aside because the animation-delay. Works fine without this delay
